### PR TITLE
iterate over upstream queries to define delegates

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,9 +1,11 @@
 import {readFileSync} from 'fs'
 import * as path from 'path'
-import * as queries from 'dom-testing-library/dist/queries'
 import {ElementHandle, EvaluateFn, JSHandle, Page} from 'puppeteer'
 import waitForExpect from 'wait-for-expect'
 import {IQueryUtils} from './typedefs'
+
+// @ts-ignore
+const queries = require('dom-testing-library/dist/queries')
 
 const domLibraryAsString = readFileSync(
   path.join(__dirname, '../dom-testing-library.js'),

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,6 +5,7 @@ import waitForExpect from 'wait-for-expect'
 import {IQueryUtils} from './typedefs'
 
 // @ts-ignore
+// tslint:disable-next-line
 const queries = require('dom-testing-library/dist/queries')
 
 const domLibraryAsString = readFileSync(
@@ -126,14 +127,14 @@ export function wait(
 export function getQueriesForElement<T>(object: T, contextFn?: ContextFn): T & IQueryUtils {
   const o = object as any
   if (!contextFn) contextFn = () => o
- 
+
   Object.entries(queries).map(([fnName]) => {
-    o[fnName] = createDelegateFor(fnName, contextFn)
+    o[fnName] = createDelegateFor(fnName as keyof IQueryUtils, contextFn)
   })
-  
+
   o.getQueriesForElement = () => getQueriesForElement(o, () => o)
   o.getNodeText = createDelegateFor<string>('getNodeText', contextFn, processNodeText)
- 
+
   return o
 }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,6 @@
 import {readFileSync} from 'fs'
 import * as path from 'path'
+import * as queries from 'dom-testing-library/dist/queries'
 import {ElementHandle, EvaluateFn, JSHandle, Page} from 'puppeteer'
 import waitForExpect from 'wait-for-expect'
 import {IQueryUtils} from './typedefs'
@@ -123,32 +124,14 @@ export function wait(
 export function getQueriesForElement<T>(object: T, contextFn?: ContextFn): T & IQueryUtils {
   const o = object as any
   if (!contextFn) contextFn = () => o
+ 
+  Object.entries(queries).map(([fnName]) => {
+    o[fnName] = createDelegateFor(fnName, contextFn)
+  })
+  
   o.getQueriesForElement = () => getQueriesForElement(o, () => o)
-  o.queryByPlaceholderText = createDelegateFor('queryByPlaceholderText', contextFn)
-  o.queryAllByPlaceholderText = createDelegateFor('queryAllByPlaceholderText', contextFn)
-  o.getByPlaceholderText = createDelegateFor('getByPlaceholderText', contextFn)
-  o.getAllByPlaceholderText = createDelegateFor('getAllByPlaceholderText', contextFn)
-  o.queryByText = createDelegateFor('queryByText', contextFn)
-  o.queryAllByText = createDelegateFor('queryAllByText', contextFn)
-  o.getByText = createDelegateFor('getByText', contextFn)
-  o.getAllByText = createDelegateFor('getAllByText', contextFn)
-  o.queryByLabelText = createDelegateFor('queryByLabelText', contextFn)
-  o.queryAllByLabelText = createDelegateFor('queryAllByLabelText', contextFn)
-  o.getByLabelText = createDelegateFor('getByLabelText', contextFn)
-  o.getAllByLabelText = createDelegateFor('getAllByLabelText', contextFn)
-  o.queryByAltText = createDelegateFor('queryByAltText', contextFn)
-  o.queryAllByAltText = createDelegateFor('queryAllByAltText', contextFn)
-  o.getByAltText = createDelegateFor('getByAltText', contextFn)
-  o.getAllByAltText = createDelegateFor('getAllByAltText', contextFn)
-  o.queryByTestId = createDelegateFor('queryByTestId', contextFn)
-  o.queryAllByTestId = createDelegateFor('queryAllByTestId', contextFn)
-  o.getByTestId = createDelegateFor('getByTestId', contextFn)
-  o.getAllByTestId = createDelegateFor('getAllByTestId', contextFn)
-  o.queryByTitle = createDelegateFor('queryByTitle', contextFn)
-  o.queryAllByTitle = createDelegateFor('queryAllByTitle', contextFn)
-  o.getByTitle = createDelegateFor('getByTitle', contextFn)
-  o.getAllByTitle = createDelegateFor('getAllByTitle', contextFn)
   o.getNodeText = createDelegateFor<string>('getNodeText', contextFn, processNodeText)
+ 
   return o
 }
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "npm run test:lint && npm run test:unit",
     "test:unit": "jest",
     "test:lint": "lint -t typescript './lib/**/*.ts'",
+    "pretest": "npm run rebuild",
     "semantic-release": "semantic-release",
     "clean": "rm -fR dist/",
     "rebuild": "npm run clean && npm run build",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compileOnSave": true,
   "compilerOptions": {
     "outDir": "./dist",
-    "target": "es2015",
+    "target": "es2017",
     "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,
@@ -13,6 +13,7 @@
     "noImplicitThis": true,
     "strictNullChecks": true,
     "preserveWatchOutput": true,
+    "lib": ["es2017", "dom"],
   },
   "include": [
     "lib/**/*"


### PR DESCRIPTION
This doesn't build (don't know Typescript), but this is a suggestion for how to define queries by iterating over the exports from dom-testing-library instead of hard-coding the names, so that the query list doesn't get out of date (the wrapper is already is missing some of the newer queries).